### PR TITLE
Whitelist webpack 3 as a peer dependency and bump to version 1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,6 @@
     "webpack-core": "^0.6.9"
   },
   "peerDependencies": {
-    "webpack": "^2.0.0 || ^2.1.0-beta || ^2.2.0-rc || ^3.0.0"
+    "webpack": ">= 2.0.0 || >= 2.1.0-beta || >= 2.2.0-rc"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "entrypoint-assets-webpack-plugin",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Exports a mapping of entries to public paths of chunks",
   "main": "index.js",
   "scripts": {
@@ -29,6 +29,6 @@
     "webpack-core": "^0.6.9"
   },
   "peerDependencies": {
-    "webpack": "^2.0.0 || ^2.1.0-beta || ^2.2.0-rc"
+    "webpack": "^2.0.0 || ^2.1.0-beta || ^2.2.0-rc || ^3.0.0"
   }
 }


### PR DESCRIPTION
Hey, love your project! It's solving a use-case for my project.

I've been using this with Webpack 3 for a few weeks with good success. Only issue I'm running into is that it complains about the missing peer dependency whenever I run an npm install. Based on my field-testing, I'm hoping we can just bump this to whitelist webpack 3.